### PR TITLE
Add parameter to control cache TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # opensheet
 
+A very awesome open source project! 🇮🇳🇮🇳🇮🇳
+
 A free, super simple, hosted API for getting Google Sheets as JSON.
 
 **Tutorial blog post:** [benborgers.com/posts/google-sheets-json](https://benborgers.com/posts/google-sheets-json)

--- a/README.md
+++ b/README.md
@@ -18,14 +18,16 @@ In order to use it:
 The format for this API is:
 
 ```
-https://opensheet.elk.sh/spreadsheet_id/tab_name
+https://opensheet.elk.sh/spreadsheet_id/tab_name?ttl=seconds
 ```
 
 For example:
 
 ```
-https://opensheet.elk.sh/1o5t26He2DzTweYeleXOGiDjlU4Jkx896f95VUHVgS8U/Test+Sheet
+https://opensheet.elk.sh/1o5t26He2DzTweYeleXOGiDjlU4Jkx896f95VUHVgS8U/Test+Sheet?ttl=60
 ```
+
+The `ttl` URL parameter is the number of seconds the response should be [cached](https://developers.cloudflare.com/workers/runtime-apis/cache/) for. Values shorter than 30 seconds will be ignored.
 
 You can also replace `tab_name` with the tab number (in the order that the tabs are arranged), if you don’t know the name. For example, to get the first sheet:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # opensheet
 
-A very awesome open source project! 🇮🇳🇮🇳🇮🇳
-
 A free, super simple, hosted API for getting Google Sheets as JSON.
 
 **Tutorial blog post:** [benborgers.com/posts/google-sheets-json](https://benborgers.com/posts/google-sheets-json)
@@ -20,16 +18,14 @@ In order to use it:
 The format for this API is:
 
 ```
-https://opensheet.elk.sh/spreadsheet_id/tab_name?ttl=seconds
+https://opensheet.elk.sh/spreadsheet_id/tab_name
 ```
 
 For example:
 
 ```
-https://opensheet.elk.sh/1o5t26He2DzTweYeleXOGiDjlU4Jkx896f95VUHVgS8U/Test+Sheet?ttl=60
+https://opensheet.elk.sh/1o5t26He2DzTweYeleXOGiDjlU4Jkx896f95VUHVgS8U/Test+Sheet
 ```
-
-The `ttl` URL parameter is the number of seconds the response should be [cached](https://developers.cloudflare.com/workers/runtime-apis/cache/) for. Values shorter than 30 seconds will be ignored.
 
 You can also replace `tab_name` with the tab number (in the order that the tabs are arranged), if you don’t know the name. For example, to get the first sheet:
 

--- a/index.js
+++ b/index.js
@@ -83,10 +83,14 @@ async function handleRequest(event) {
     rows.push(rowData);
   });
 
+  const { searchParams } = new URL(request.url);
+  const ttlSeconds = parseInt(searchParams.get('ttl')) || 30;
+  if (ttlSeconds < 30) ttlSeconds = 30;
+
   const apiResponse = new Response(JSON.stringify(rows), {
     headers: {
       "Content-Type": "application/json",
-      "Cache-Control": "s-maxage=30",
+      "Cache-Control": `s-maxage=${ttlSeconds}`,
       "Access-Control-Allow-Origin": "*",
     },
   });

--- a/index.js
+++ b/index.js
@@ -83,8 +83,8 @@ async function handleRequest(event) {
     rows.push(rowData);
   });
 
-  const { searchParams } = new URL(request.url);
-  const ttlSeconds = parseInt(searchParams.get('ttl')) || 30;
+  const { searchParams } = new URL(event.request.url);
+  let ttlSeconds = parseInt(searchParams.get('ttl')) || 30;
   if (ttlSeconds < 30) ttlSeconds = 30;
 
   const apiResponse = new Response(JSON.stringify(rows), {


### PR DESCRIPTION
This pull request adds an optional `ttl` URL parameter to control how long the request is cached for. I tested, and this does not allow the cache to be invalidated earlier than 30 seconds—it appears that Cloudflare ignores cache headers when matching requests in the cache.