### PR TITLE
Support returning raw data

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ https://opensheet.elk.sh/1o5t26He2DzTweYeleXOGiDjlU4Jkx896f95VUHVgS8U/1
 
 _Take note that the first sheet in order is numbered `1`, not `0`._
 
+Adding the `?raw=true` URL parameter returns the raw, unformatted data from the sheet. Without this parameter, Google Sheets formats numbers, dates, and other data types, but with `?raw=true`, you'll get the underlying values.
+
 ## Caching
 
 Responses are cached for 30 seconds in order to improve performance and to avoid hitting Google Sheets’ rate limits, so it might take up to 30 seconds for fresh edits to show up in the API response.

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ async function handleRequest(event) {
 
   const rows = [];
 
-  const rawRows = (result.values || []);
+  const rawRows = result.values || [];
   const headers = rawRows.shift();
 
   rawRows.forEach((row) => {


### PR DESCRIPTION
~~This PR adds the `?isoDates=true` URL parameter. If enabled, opensheet will request dates in their underlying format (days since December 31, 1899) and convert them to ISO timestamps before returning them.~~

This PR adds the `?raw=true` URL parameter. If enabled, opensheet will return the sheet without text formatting (e.g., commas in numbers). This is useful in getting dates and numbers as their underlying values, not the user-formatted values.

Previously, I automatically formatted dates as ISO strings, but the fun thing is that Google Sheets returns dates as numbers, and also returns numbers as numbers. So there's no way to distinguish what's a number and what's a date. If you know your sheet will return dates, you can use this option and convert them yourself.